### PR TITLE
Add support for handling additional Exceptions with PendingFeature ...

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/PendingFeatureExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/PendingFeatureExtension.java
@@ -11,9 +11,9 @@ public class PendingFeatureExtension extends AbstractAnnotationDrivenExtension<P
   @Override
   public void visitFeatureAnnotation(PendingFeature annotation, FeatureInfo feature) {
     if (feature.isParameterized()) {
-      feature.addInterceptor(new PendingFeatureIterationInterceptor());
+      feature.addInterceptor(new PendingFeatureIterationInterceptor(annotation.exceptions()));
     } else {
-      feature.getFeatureMethod().addInterceptor(new PendingFeatureInterceptor());
+      feature.getFeatureMethod().addInterceptor(new PendingFeatureInterceptor(annotation.exceptions()));
     }
   }
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/PendingFeatureInterceptor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/PendingFeatureInterceptor.java
@@ -8,12 +8,26 @@ import org.spockframework.runtime.extension.IMethodInvocation;
  * @author Leonard Brünings
  */
 class PendingFeatureInterceptor implements IMethodInterceptor {
+  private final Class<? extends Throwable>[] handledExceptions;
+
+  public PendingFeatureInterceptor(Class<? extends Throwable>[] handledExceptions) {
+
+    this.handledExceptions = handledExceptions;
+  }
+
   @Override
   public void intercept(IMethodInvocation invocation) throws Throwable {
     try {
       invocation.proceed();
     } catch (AssertionError e) {
       throw new AssumptionViolatedException("Feature not yet implemented correctly.");
+    } catch (Exception e) {
+      for (Class<? extends Throwable> exception : handledExceptions) {
+        if(exception.isInstance(e)) {
+          throw new AssumptionViolatedException("Feature not yet implemented correctly.");
+        }
+      }
+      throw e;
     }
     throw new AssertionError("Feature is marked with @PendingFeature but passes unexpectedly");
   }

--- a/spock-core/src/main/java/spock/lang/PendingFeature.java
+++ b/spock-core/src/main/java/spock/lang/PendingFeature.java
@@ -2,7 +2,6 @@ package spock.lang;
 
 
 import org.spockframework.runtime.extension.ExtensionAnnotation;
-import org.spockframework.runtime.extension.builtin.IgnoreExtension;
 import org.spockframework.runtime.extension.builtin.PendingFeatureExtension;
 import org.spockframework.util.Beta;
 
@@ -40,4 +39,10 @@ import java.lang.annotation.Target;
 @Target({ElementType.METHOD})
 @ExtensionAnnotation(PendingFeatureExtension.class)
 public @interface PendingFeature {
+  /**
+   * Additional types of Exceptions to be ignored, defaults to Exception.
+   *
+   * @return array of Exception classes to ignore.
+   */
+  Class<? extends Throwable>[] exceptions() default {Exception.class};
 }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/PendingFeatureExtensionSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/PendingFeatureExtensionSpec.groovy
@@ -23,6 +23,42 @@ class Foo extends Specification {
     result.ignoreCount == 0
   }
 
+  def "@PendingFeature marks feature that fails with exception as skipped"() {
+    when:
+    def result = runner.runWithImports("""
+
+class Foo extends Specification {
+  @PendingFeature
+  def bar() {
+    expect:
+    throw new Exception()
+  }
+}
+    """)
+
+    then:
+    notThrown(AssertionError)
+    result.runCount == 1
+    result.failureCount == 0
+    result.ignoreCount == 0
+  }
+  def "@PendingFeature rethrows non handled exceptions"() {
+    when:
+    def result = runner.runWithImports("""
+
+class Foo extends Specification {
+  @PendingFeature(exceptions=[RuntimeException])
+  def bar() {
+    expect:
+    throw new Exception()
+  }
+}
+    """)
+
+    then:
+    thrown(Exception)
+  }
+
   def "@PendingFeature marks passing feature as failed"() {
     when:
     runner.runWithImports("""


### PR DESCRIPTION
Add support for handling additional Exception types with the PendingFeature annotation to allow features that are failing with exceptions instead of AssertionErrors.

This extension of `@PendingFeature` was suggested in #523
